### PR TITLE
Allow Alpha to be used in (new) shortened format

### DIFF
--- a/src/starling/extensions/animate/AnimationAtlas.as
+++ b/src/starling/extensions/animate/AnimationAtlas.as
@@ -267,8 +267,10 @@ package starling.extensions.animate
 
             // fix shortened names
             AN: "animation",
+            AM: "alphaMultiplier",
             ASI: "atlasSpriteInstance",
             BM: "bitmap",
+            C: "color",
             DU: "duration",
             E: "elements",
             FF: "firstFrame",
@@ -281,6 +283,7 @@ package starling.extensions.animate
             LP: "loop",
             M3D: "matrix3D",
             MD: "metadata",
+            M: "mode",
             N: "name",
             POS: "position",
             S: "symbols",

--- a/src/starling/extensions/animate/Symbol.as
+++ b/src/starling/extensions/animate/Symbol.as
@@ -201,7 +201,9 @@ package starling.extensions.animate
         {
             if (data)
             {
-                alpha = data.mode == "Alpha" || data.mode == "Advanced" ? data.alphaMultiplier : 1.0;
+                var mode:String = data.mode;
+                const ALPHA_MODES:Array = ["Alpha", "Advanced", "AD"];
+                alpha = (ALPHA_MODES.indexOf(mode) >= 0) ? data.alphaMultiplier : 1.0;
             }
             else
             {


### PR DESCRIPTION
Our art team wanted to use this extension and it did not work with alpha fading exported from AnimateCC 2019.2 - turns out that you had already implemented alpha property, but just hadn't use the new minified tags.